### PR TITLE
chore: update dinar-ephemeral-alpha

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,9 +133,15 @@
               sops-nix.homeManagerModules.sops
             ];
           }
+          {
+            # GRUB timeout
+            boot.loader.timeout = nixpkgs.lib.mkForce 1;
+
+            # Load into a tmpfs during stage-1
+            boot.kernelParams = [ "copytoram" ];
+          }
         ];
-        customFormats = customFormats;
-        format = "copytoram-iso";
+        format = "install-iso";
       };
 
       darwinConfigurations."ponkila-persistent-epsilon" = darwin.lib.darwinSystem {

--- a/hosts/dinar-ephemeral-alpha/default.nix
+++ b/hosts/dinar-ephemeral-alpha/default.nix
@@ -25,11 +25,6 @@ in
   erigon = rec {
     endpoint = infra.ip;
     datadir = "/mnt/eth/erigon";
-    mount = {
-      source = "/dev/sda3";
-      target = datadir;
-      type = "ext4";
-    };
   };
 
   # Lighthouse options
@@ -42,11 +37,6 @@ in
       enable = false;
       history-length = 256;
       max-db-size = 16;
-    };
-    mount = {
-      source = "/dev/sda2";
-      target = datadir;
-      type = "ext4";
     };
   };
 
@@ -65,10 +55,10 @@ in
     {
       enable = true;
 
-      description = "secrets storage";
+      description = "storage";
 
       what = "/dev/sda1";
-      where = "/mnt/secrets";
+      where = "/mnt/eth";
       type = "ext4";
 
       before = [ "sops-nix.service" "sshd.service" ];

--- a/hosts/dinar-ephemeral-alpha/mounts.nix
+++ b/hosts/dinar-ephemeral-alpha/mounts.nix
@@ -1,9 +1,9 @@
-# sudo nix run github:nix-community/disko -- --mode zap_create_mount ./dinar-disko-config.nix --arg disks '[ "/dev/sda" ]'
+# sudo nix run github:nix-community/disko -- --mode zap_create_mount ./mounts.nix --arg disks '[ "/dev/sda" ]'
 
 { disks ? [ "/dev/sda" ], ... }: {
   disko.devices = {
     disk = {
-      sda = {
+      disk0 = {
         device = builtins.elemAt disks 0;
         type = "disk";
         content = {
@@ -13,37 +13,13 @@
             {
               name = "sda1";
               start = "1MiB";
-              end = "10MiB";
-              bootable = false;
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                # systemd should handle mount
-                #mountpoint = "/secrets";
-              };
-            }
-            {
-              name = "sda2";
-              start = "10MiB";
-              end = "50%";
-              bootable = false;
-              content = {
-                type = "filesystem";
-                format = "ext4";
-                # systemd should handle mount
-                #mountpoint = "/eth/lighthouse";
-              };
-            }
-            {
-              name = "sda3";
-              start = "50%";
               end = "100%";
               bootable = false;
               content = {
                 type = "filesystem";
                 format = "ext4";
-                # systemd should handle mount
-                #mountpoint = "/eth/erigon";
+                # mountpoint has invisible /mnt prefix 
+                mountpoint = "/eth";
               };
             }
           ];

--- a/hosts/dinar-ephemeral-alpha/mounts.nix
+++ b/hosts/dinar-ephemeral-alpha/mounts.nix
@@ -3,7 +3,7 @@
 { disks ? [ "/dev/sda" ], ... }: {
   disko.devices = {
     disk = {
-      disk0 = {
+      sda = {
         device = builtins.elemAt disks 0;
         type = "disk";
         content = {
@@ -14,12 +14,14 @@
               name = "sda1";
               start = "1MiB";
               end = "100%";
+              part-type = "primary";
               bootable = false;
               content = {
                 type = "filesystem";
                 format = "ext4";
                 # mountpoint has invisible /mnt prefix 
-                mountpoint = "/eth";
+                # systemd should handle mount
+                #mountpoint = "/eth";
               };
             }
           ];

--- a/modules/eth/erigon.nix
+++ b/modules/eth/erigon.nix
@@ -23,23 +23,27 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # only execute this if cfg.mounts are set
-    (mkIf cfg.mounts {
-      systemd.mounts = [
-        {
-          enable = true;
+    # only execute this if mount options are set
+    (mkIf
+      (cfg.mount ? cfg.mount.source &&
+        cfg.mount ? cfg.mount.target &&
+        cfg.mount ? cfg.mount.type)
+      {
+        systemd.mounts = [
+          {
+            enable = true;
 
-          description = "erigon storage";
+            description = "erigon storage";
 
-          what = cfg.mount.source;
-          where = cfg.mount.target;
-          options = lib.mkDefault "noatime";
-          type = cfg.mount.type;
+            what = cfg.mount.source;
+            where = cfg.mount.target;
+            options = lib.mkDefault "noatime";
+            type = cfg.mount.type;
 
-          wantedBy = [ "multi-user.target" ];
-        }
-      ];
-    })
+            wantedBy = [ "multi-user.target" ];
+          }
+        ];
+      })
     # always execute this
     (mkIf cfg.enable {
       # package

--- a/modules/eth/erigon.nix
+++ b/modules/eth/erigon.nix
@@ -23,11 +23,6 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # package
-    environment.systemPackages = with pkgs; [
-      erigon
-    ];
-
     # only execute this if cfg.mounts are set
     (mkIf cfg.mounts {
       systemd.mounts = [
@@ -47,6 +42,11 @@ in
     })
     # always execute this
     (mkIf cfg.enable {
+      # package
+      environment.systemPackages = with pkgs; [
+        erigon
+      ];
+
       # service
       systemd.services.erigon = {
         enable = true;

--- a/modules/eth/erigon.nix
+++ b/modules/eth/erigon.nix
@@ -24,9 +24,9 @@ in
 
   config = mkIf cfg.enable (mkMerge [
     # package
-      environment.systemPackages = with pkgs; [
-        erigon
-      ];
+    environment.systemPackages = with pkgs; [
+      erigon
+    ];
 
     # only execute this if cfg.mounts are set
     (mkIf cfg.mounts {
@@ -43,10 +43,10 @@ in
 
           wantedBy = [ "multi-user.target" ];
         }
-      ]; 
+      ];
     })
     # always execute this
-    (mkIf cfg.enable { 
+    (mkIf cfg.enable {
       # service
       systemd.services.erigon = {
         enable = true;

--- a/modules/eth/erigon.nix
+++ b/modules/eth/erigon.nix
@@ -23,6 +23,11 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
+    # package
+      environment.systemPackages = with pkgs; [
+        erigon
+      ];
+
     # only execute this if cfg.mounts are set
     (mkIf cfg.mounts {
       systemd.mounts = [

--- a/modules/eth/lighthouse-beacon.nix
+++ b/modules/eth/lighthouse-beacon.nix
@@ -44,23 +44,27 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # only execute this if cfg.mounts are set
-    (mkIf cfg.mounts {
-      systemd.mounts = [
-        {
-          enable = true;
+    # only execute this if mount options are set
+    (mkIf
+      (cfg.mount ? cfg.mount.source &&
+        cfg.mount ? cfg.mount.target &&
+        cfg.mount ? cfg.mount.type)
+      {
+        systemd.mounts = [
+          {
+            enable = true;
 
-          description = "lighthouse storage";
+            description = "lighthouse storage";
 
-          what = cfg.mount.source;
-          where = cfg.mount.target;
-          options = lib.mkDefault "noatime";
-          type = cfg.mount.type;
+            what = cfg.mount.source;
+            where = cfg.mount.target;
+            options = lib.mkDefault "noatime";
+            type = cfg.mount.type;
 
-          wantedBy = [ "multi-user.target" ];
-        }
-      ];
-    })
+            wantedBy = [ "multi-user.target" ];
+          }
+        ];
+      })
     # always execute this
     (mkIf cfg.enable {
       # package

--- a/modules/eth/lighthouse-beacon.nix
+++ b/modules/eth/lighthouse-beacon.nix
@@ -43,68 +43,73 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    # package
-    environment.systemPackages = with pkgs; [
-      lighthouse
-    ];
+  config = mkIf cfg.enable (mkMerge [
+    # only execute this if cfg.mounts are set
+    (mkIf cfg.mounts {
+      systemd.mounts = [
+        {
+          enable = true;
 
-    systemd.mounts = [
-      {
+          description = "lighthouse storage";
+
+          what = cfg.mount.source;
+          where = cfg.mount.target;
+          options = lib.mkDefault "noatime";
+          type = cfg.mount.type;
+
+          wantedBy = [ "multi-user.target" ];
+        }
+      ];
+    })
+    # always execute this
+    (mkIf cfg.enable {
+      # package
+      environment.systemPackages = with pkgs; [
+        lighthouse
+      ];
+
+      # service
+      systemd.services.lighthouse = {
         enable = true;
 
-        description = "lighthouse storage";
+        description = "beacon, mainnet";
+        requires = [ "wg0.service" ];
+        after = [ "wg0.service" "mev-boost.service" ];
 
-        what = cfg.mount.source;
-        where = cfg.mount.target;
-        options = lib.mkDefault "noatime";
-        type = cfg.mount.type;
+        serviceConfig = {
+          Restart = "always";
+          RestartSec = "5s";
+          User = "core";
+          Group = "core";
+          Type = "simple";
+        };
 
+        script = ''${pkgs.lighthouse}/bin/lighthouse bn \
+          --datadir ${cfg.datadir} \
+          --network mainnet \
+          --http --http-address ${cfg.endpoint} \
+          --execution-endpoint ${cfg.exec.endpoint} \
+          --execution-jwt ${cfg.datadir}/jwt.hex \
+          --builder ${cfg.mev-boost.endpoint} \
+          --prune-payloads false \
+          --metrics \
+          ${if cfg.slasher.enable then
+            "--slasher "
+            + " --slasher-history-length " + (toString cfg.slasher.history-length)
+            + " --slasher-max-db-size " + (toString cfg.slasher.max-db-size)
+          else "" }
+        '';
         wantedBy = [ "multi-user.target" ];
-      }
-    ];
-
-    # service
-    systemd.services.lighthouse = {
-      enable = true;
-
-      description = "beacon, mainnet";
-      requires = [ "wg0.service" ];
-      after = [ "wg0.service" "mev-boost.service" ];
-
-      serviceConfig = {
-        Restart = "always";
-        RestartSec = "5s";
-        User = "core";
-        Group = "core";
-        Type = "simple";
       };
 
-      script = ''${pkgs.lighthouse}/bin/lighthouse bn \
-        --datadir ${cfg.datadir} \
-        --network mainnet \
-        --http --http-address ${cfg.endpoint} \
-        --execution-endpoint ${cfg.exec.endpoint} \
-        --execution-jwt ${cfg.datadir}/jwt.hex \
-        --builder ${cfg.mev-boost.endpoint} \
-        --prune-payloads false \
-        --metrics \
-        ${if cfg.slasher.enable then
-          "--slasher "
-          + " --slasher-history-length " + (toString cfg.slasher.history-length)
-          + " --slasher-max-db-size " + (toString cfg.slasher.max-db-size)
-        else "" }
-      '';
-      wantedBy = [ "multi-user.target" ];
-    };
-
-    # firewall
-    networking.firewall = {
-      allowedTCPPorts = [ 9000 ];
-      allowedUDPPorts = [ 9000 ];
-      interfaces."wg0".allowedTCPPorts = [
-        5052 # lighthouse
-      ];
-    };
-  };
+      # firewall
+      networking.firewall = {
+        allowedTCPPorts = [ 9000 ];
+        allowedUDPPorts = [ 9000 ];
+        interfaces."wg0".allowedTCPPorts = [
+          5052 # lighthouse
+        ];
+      };
+    })
+  ]);
 }


### PR DESCRIPTION
Updated dinar-ephemeral-alpha /dev/sda mount to have a single partition, mounted at /mnt/eth. 

Modifications were made to erigon and lighthouse configurations to support the single partition mount. As a result, the mounting options under each node setting in host-specific configuration are now optional, requiring traditional systemd.mounts for mounting.
