### PR TITLE
formats: use "very fast" zstd compression

### DIFF
--- a/system/formats/netboot-kexec.nix
+++ b/system/formats/netboot-kexec.nix
@@ -9,6 +9,7 @@
     # Closures to be copied to the Nix store, namely the init
     # script and the top-level system configuration directory.
     storeContents = [ config.system.build.toplevel ];
+    comp = "zstd -Xcompression-level 2";
   };
 
   # Create the initrd


### PR DESCRIPTION
This PR adds "very fast" (level 2) zstd compression for kexec images. This significantly reduces build times, but also increases the size of produced disk images.

We should look into also integrating this into creation of ISO files, if possible. Hence, this PR is marked as draft.