### PR TITLE
pre-commit-hooks: init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/5dn5n2hrzlg2gdfbds321iqcfh4jcafm-pre-commit-config.json

--- a/flake.lock
+++ b/flake.lock
@@ -239,6 +239,21 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "foundry-nix": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -622,6 +637,28 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks-nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667612001,
+        "narHash": "sha256-bnXYCDzkviKNeYwnh3YW2HpgSgUMnSGVsTtHNLXBXfE=",
+        "owner": "hercules-ci",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1ee64b852871d790a49f0b8e17b788f5eeb2d52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "ref": "flakeModule",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "darwin": "darwin",
@@ -633,6 +670,7 @@
         "mission-control": "mission-control_2",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-stable": "nixpkgs-stable_2",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
         "sops-nix": "sops-nix"
       }
     },


### PR DESCRIPTION
This pull request introduces pre-commit hooks. 

The added functionality should include running code formatters, such as `nixfmt` and `shellcheck` before each commit. Additionally, the hooks should check success of every build and generate diffs for every host (ref to [this review](https://github.com/ponkila/homestaking-infra/pull/37#discussion_r1206592365)).

By implementing these changes, this would resolve the following issues: #25, #26, and potentially #33.