### PR TITLE
sops: add kiln testnet validator keys

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -4,6 +4,10 @@ keys:
   - &juuso 8F84B8738E67A3453F05D29BC2DC6A67CB7F891F
   - &ponkila-ephemeral-beta age1rahna5rce9mj0js0p7dgt6wseqyzxjawva82tfdelzuvmngr5fdqa2geuy
 creation_rules:
+  - path_regex: validator_keys/kiln/[^/]+\.yaml$
+    key_groups:
+      - pgp:
+        - *juuso
   - path_regex: hosts/ponkila-ephemeral-beta/secrets/[^/]+\.yaml$
     key_groups:
       - pgp:

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,33 @@
     "devshell": {
       "inputs": {
         "nixpkgs": [
-          "nixobolus",
           "ethereum-nix",
           "nixpkgs"
         ],
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685972731,
+        "narHash": "sha256-VpwVUthxs3AFgvWxGTHu+KVDnS/zT3xkCtmjX2PjNQs=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "6b2554d28d46bfa6e24b941e999a145760dad0e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixobolus",
+          "ethereum-nix",
+          "nixpkgs"
+        ],
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1685972731,
@@ -109,16 +131,44 @@
       "inputs": {
         "devshell": "devshell",
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts_2",
-        "flake-root": "flake-root_2",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
         "foundry-nix": "foundry-nix",
         "hercules-ci-effects": "hercules-ci-effects",
         "nixpkgs": [
-          "nixobolus",
           "nixpkgs"
         ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1686573052,
+        "narHash": "sha256-FmSoTUOWMTfA/CHM0mlB31pNOvKa6VMyGgf/770Fdts=",
+        "owner": "nix-community",
+        "repo": "ethereum.nix",
+        "rev": "5f60e22d9ae3ef826fab9d9bc7fcde19daebddd3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "ethereum.nix",
+        "type": "github"
+      }
+    },
+    "ethereum-nix_2": {
+      "inputs": {
+        "devshell": "devshell_2",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_5",
+        "flake-root": "flake-root_3",
+        "foundry-nix": "foundry-nix_2",
+        "hercules-ci-effects": "hercules-ci-effects_2",
+        "nixpkgs": [
+          "nixobolus",
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1686573052,
@@ -149,9 +199,27 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "locked": {
+        "lastModified": 1680531544,
+        "narHash": "sha256-8qbiDTYb1kGaDADRXTItpcMKQ1TeQVkuof6oEwHUvVA=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "95e78dc12268c5e4878621845c511077f3798729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "ethereum-nix",
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1685662779,
@@ -168,6 +236,64 @@
       }
     },
     "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "ethereum-nix",
+          "hercules-ci-effects",
+          "hercules-ci-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1680392223,
+        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
           "nixobolus",
@@ -189,9 +315,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_6": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1685662779,
@@ -206,7 +332,7 @@
         "type": "indirect"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": [
           "nixobolus",
@@ -230,9 +356,9 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_8": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1685662779,
@@ -293,6 +419,21 @@
         "type": "github"
       }
     },
+    "flake-root_4": {
+      "locked": {
+        "lastModified": 1680964220,
+        "narHash": "sha256-dIdTYcf+KW9a4pKHsEbddvLVSfR1yiAJynzg2x0nfWg=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "f1c0b93d05bdbea6c011136ba1a135c80c5b326c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -310,6 +451,21 @@
     },
     "flake-utils_2": {
       "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
         "lastModified": 1667077288,
         "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
         "owner": "numtide",
@@ -326,6 +482,29 @@
     "foundry-nix": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "ethereum-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685870001,
+        "narHash": "sha256-ijUNyTvT/dT9JOcsNiVtu/u1Eicf0HqQ7SPyZ5yRU84=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "c80b4ea3bdce135164a7aac78aafb7c619b2dd23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "ref": "monthly",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "foundry-nix_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixobolus",
           "ethereum-nix",
@@ -363,9 +542,25 @@
         "type": "github"
       }
     },
+    "haskell-flake_2": {
+      "locked": {
+        "lastModified": 1678745009,
+        "narHash": "sha256-ujfwSrkxThmHJozibkCnJmlXLVyxm+Cbo2Q4wXPbCS4=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "26852ade574c712bc3912ad28de52b0c4cf7d4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "ref": "0.2.0",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
     "hercules-ci-agent": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_3",
         "haskell-flake": "haskell-flake",
         "nixpkgs": "nixpkgs"
       },
@@ -382,11 +577,50 @@
         "type": "indirect"
       }
     },
+    "hercules-ci-agent_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_7",
+        "haskell-flake": "haskell-flake_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1686138353,
+        "narHash": "sha256-e0wDTIySFCfZMSYQNVGY/d6jjwcua3y6igouI8CejQ8=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-agent",
+        "rev": "febf6540ed5fd55812933c159e59742743277b30",
+        "type": "github"
+      },
+      "original": {
+        "id": "hercules-ci-agent",
+        "type": "indirect"
+      }
+    },
     "hercules-ci-effects": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_2",
         "hercules-ci-agent": "hercules-ci-agent",
         "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1686181431,
+        "narHash": "sha256-S1IsZGwcMChJg3mgnKdFxh2c/D77B1NoOCd8s3tQQIg=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "657935127398706754113c1cea5800798ecb99a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
+    "hercules-ci-effects_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_6",
+        "hercules-ci-agent": "hercules-ci-agent_2",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1686181431,
@@ -477,12 +711,12 @@
       "inputs": {
         "darwin": "darwin_2",
         "disko": "disko_2",
-        "ethereum-nix": "ethereum-nix",
-        "flake-parts": "flake-parts_5",
-        "flake-root": "flake-root_3",
+        "ethereum-nix": "ethereum-nix_2",
+        "flake-parts": "flake-parts_8",
+        "flake-root": "flake-root_4",
         "home-manager": "home-manager_2",
         "mission-control": "mission-control_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -569,6 +803,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1686431482,
@@ -633,6 +885,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1686398752,
+        "narHash": "sha256-nGWNQVhSw4VSL+S0D0cbrNR9vs9Bq7rlYR+1K5f5j6w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a30520bf8eabf8a5c37889d661e67a2dbcaa59e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1686178082,
@@ -650,11 +918,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1686501370,
-        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
         "type": "github"
       },
       "original": {
@@ -665,6 +933,37 @@
       }
     },
     "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1686178082,
+        "narHash": "sha256-ll289AxpC7tomi516m5w8yG/U81k3IR68VGui19pRyw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b9e05544c9b0a382d3416d602791a63ec2e63217",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1686592866,
+        "narHash": "sha256-riGg89eWhXJcPNrQGcSwTEEm7CGxWC06oSX44hajeMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0eeebd64de89e4163f4d3cf34ffe925a5cf67a05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1686501370,
         "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
@@ -680,7 +979,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1667292599,
         "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
@@ -694,7 +993,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1686398752,
         "narHash": "sha256-nGWNQVhSw4VSL+S0D0cbrNR9vs9Bq7rlYR+1K5f5j6w=",
@@ -712,8 +1011,8 @@
     },
     "pre-commit-hooks-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_5"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1667612001,
@@ -734,12 +1033,13 @@
       "inputs": {
         "darwin": "darwin",
         "disko": "disko",
-        "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
+        "ethereum-nix": "ethereum-nix",
+        "flake-parts": "flake-parts_4",
+        "flake-root": "flake-root_2",
         "home-manager": "home-manager",
         "mission-control": "mission-control",
         "nixobolus": "nixobolus",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sops-nix": "sops-nix"
@@ -747,7 +1047,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
@@ -779,7 +1079,43 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "ethereum-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685519364,
+        "narHash": "sha256-rE9c9jWDSc5Nj0OjNzBENaJ6j4YBphcqSPia2IwCMLA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "6521a278bcba66b440554cc1350403594367b4ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixobolus",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
     darwin.url = "github:lnl7/nix-darwin";
     disko.inputs.nixpkgs.follows = "nixpkgs";
     disko.url = "github:nix-community/disko";
+    ethereum-nix.url = "github:nix-community/ethereum.nix";
+    ethereum-nix.inputs.nixpkgs.follows = "nixpkgs";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
@@ -89,6 +91,7 @@
             rsync
             zstd
             cpio
+            inputs.ethereum-nix.packages.${system}.staking-deposit-cli
           ];
           inputsFrom = [
             config.flake-root.devShell

--- a/validator_keys/kiln/default.yaml
+++ b/validator_keys/kiln/default.yaml
@@ -1,0 +1,25 @@
+deposit_data-1652905715.json: ENC[AES256_GCM,data:EwbXtxN2+DjNVAtjF/eAIDXoP3/OkWgY+lhpUULKMfHJRYwG7UYg9OkaiCBxmkGtHPXZgYh6Yc9Ym2BKiFnePYMgp+X+FdL5i2rL6A2h22PZzZ/1cMJdqBBDyY0+8hysipdMVN75i7DUScM/fCJV8/BWr/026ye+x6WaGTp8XY9rfSmlV0lL17KipypXc/XIBjeQFeAFGxmPb1cFbC8Glq0V/xdhci9KsEmuKQnYLBMhUiZpBwiYSXVO1IvQiN1/nPgbZmsd9TitmF/hFfa4CYBy8wK648laoiNSke3bylLow7BRQDELVB+0NQKPfLWfzH1GKiKQfp/t6Oc1+vTDxgXSUhbONfagq0dzsea3yQhxVlob3sBO99ZjIriJIpLggUhhuRZkiDIFFVEsfvp8pnUeoBKfkje6OzN2rY8rwO4MHor/amQ/LnZUjtJ8GcctF4i74V/Fm5yi3gAw+cfRSGLseM8bQB1b23Puq97QcwyZPbex+QJTazL1d8R8Vopdlsclz3eciKA6IBlPVBn9RBgx0zDnds956MSiABgjaSrNdVQnru+/qxzumPEmoKGCVWRwjD21u7YX0BspYJkdm058n5vhSjO7vvpGwWCgzNq7NoRdS34tKYPOBk5/t/o3QITvOADc3LJd24QzeWQSuMqj9hh/pYZjPLK2jtztEUZIyxhvV4FJMKN2kPRjE4AnBZ7rGZGsxvLVuVkTL5+ZWiGgmX9CHokVTico0p7qrEJvO644py85XmcgKxl83jwClxwBhFiny4kXAmBW1zSa14vQWN5csWMDurMbZVDOaHr98ttvsyQIkS3lkkJmwEhz0QV8lI8+FOGoNR4jnVYs/E+EZuvGmM6kpA+Yk7RPyfVVJU6qdOboLDp9MA4C7mu9AKtdTJScKgKKwYp+BmQqm85PO8eFGJfBfflsUnBguQ==,iv:ducTT0xLWkrbonmKNCXXvKhcPYbIth+P1ZeHkBCq9K8=,tag:rrxLMCqDmc5aXo+0ZNY56g==,type:str]
+keystore-m_12381_3600_0_0_0-1652905715.json: ENC[AES256_GCM,data:Yp+p/IboPJWY94uc4q+ILYrnNtacIluM2uT7juXCDRfjUq5iD4kbr5HYO1ehihMhyu28abqFCukoiUPUJlnJE+CeZxzzf/09IYCZD/+sXn9PApIM4DrnqWWjDH7HtE95n7BJBs1eZOSsT9FTk9ZPF0XoMgjZCq1F5naSizAnyPzMk/Di1SRrZ3Dw2Mqq5dTnEzOcIvO7tOCGACW8GDPe5eyebG6JARLQFTD9xN79MHEVGpv+/atKWgdhvFGDyz2jgo/831kfR3pkbD13n6g+6ntuvxhEW/5s95tnDOlgmLlfHq2sG5x/OSSKCUt1hTie6p4dQa8HUmvlITeUV0N6fBhpNiaFmZmbnwNoBt03ShwqatshGu6uS04qNswbEJi3hz7yK8qvoMpH+bMp0Qhumv+L+3X5uXCdbTGq3x1GcsP9csCWaq/yV1uwbxxcsfzcbJeWotY/IRhI/aGulfFEJUYOcrijaS5Sbp6+9121RXfi7MIvZIt6XycKNYmiGHeUH4MHimnJbgxYkqdnLMDax+hJtN0Njp8C4wd3sah5XHVXigAqabbOEj7GVBwidl0kermHpschclSspbr2ONUpMEoqUIB7BCzjO6ARG6r7JIX7KDwAZBhOqCvYrjqSs1l+Usbl8l37Ben0HqbbhOdMvmcm4yXcjJdK4pLjxHoHAPJRN5cufYb401NJAA9KNT/AMp+mxd9HQopttj1TbghbAhL47HYVJ7Z748+YM4t7FXdiZZ4FL4f0olrGc10p88Q1RX+ChxqMdo/fu6ptwP2UOR8dvb+H+6ML8iYmyL71G+NzqQWg10ZQcAA2UudHfL4MkoAxiS/PIbrX/YBclH1Zgxe4fVYTkPSPGBkTePdh5xIzPty5JPjOgUIKnKGiVlruOx3HzcakVXOMZov3BProf2yf7xo32AWgsjAoRSG8pVp04oxRPDU=,iv:ouNtKoTxpI55xn6Uyx0/yQXUWEDTyYVB021TjG0Xc1E=,tag:MNFuQCZ6kjxRcy042CQUCQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-06-15T22:40:33Z"
+    mac: ENC[AES256_GCM,data:IJw7CTiU67bitta+ypdqXm7hyrYzZfIOfybxPTtF/Osx0ChiOKcSnpcg1rMvBaZOF7T0heY8c542ExVR9C+uiCprZi1l4/nvZw8k6d7gayDG513B4dDepvuh0kQBDoKPsoGTn/Iu/wP0k3Hn/8BqMMBfTT73kUGFHTL7jEvNEfM=,iv:ccetnfCrRv35p6LKUDqIcE6OW17vk7GS7kCl20tn8jM=,tag:Vrj5SqvEdRfZTGwL4uhpAA==,type:str]
+    pgp:
+        - created_at: "2023-06-15T22:36:13Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hH4DfXeKk69lOL0SAgMEX5PPCRTAlP8yr4eNtF7bhIgwrtOFbKglAAHt+XoFLJBU
+            4Opi+9mHC5mdmU/H1ThCvQwIcdZrD/oJtborxuRLJzBsKIPVWq8b0UXJwXLGwA8y
+            ZyzKhrYJsVq5O0CbIIPnxsTgKQ0nvNg08Jrk6dOpMR7SXgGlVVCpFnt79wEcfZRX
+            u8QZgowO/KcPEa2JZSaXPvUr95iCA/3fiCdXWtoAudN3h5eKzU+yz+y0pgS9BP+Q
+            UMWMP2tzCwSa3VGi6Om7SLfA5wJdnhMW8tvA0pywUX8=
+            =YBmK
+            -----END PGP MESSAGE-----
+          fp: 8F84B8738E67A3453F05D29BC2DC6A67CB7F891F
+    unencrypted_suffix: _unencrypted
+    version: 3.7.3


### PR DESCRIPTION
While clearing my computer, I found old kiln testnet keys for validators. I added them here for archival.

That is, these keys deposited account of Kiln testnet keys. I'm open to suggestions where should secrets that are shared among multiple nodes go. We could later see how we could link these up for our validator nodes, and how to try them out. These might be useful for end-to-end testing purposes for validators: consider a case where we want to update some node, we could run the updates first on a testnet, see if everything works, and if so, continue updating the rest of the fleet with the actual keys.

The point of end-to-end testing was brought up by people on ssv.network, and could be a nice way to do step-by-step updates later on.