### PR TITLE
hetzner-ephemeral-alpha: open 8081

### DIFF
--- a/nixosConfigurations/hetzner-ephemeral-alpha/default.nix
+++ b/nixosConfigurations/hetzner-ephemeral-alpha/default.nix
@@ -114,5 +114,11 @@
     openFirewall = true;
   };
 
+  # Port for HomestakerOS
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 8081 ];
+  };
+
   system.stateVersion = "23.05";
 }


### PR DESCRIPTION
Opening a port for testing [HomestakerOS](https://github.com/ponkila/HomestakerOS).