### PR TITLE
hetzner-ephemeral-alpha: caddy as load-balancer

### DIFF
--- a/nixosConfigurations/dinar-ephemeral-alpha/default.nix
+++ b/nixosConfigurations/dinar-ephemeral-alpha/default.nix
@@ -142,6 +142,8 @@ in {
     extraOptions = "--follow";
   };
 
+  services.netdata.enable = true;
+
   services.getty.autologinUser = "core";
 
   system.stateVersion = "23.05";


### PR DESCRIPTION
- changes the load balancer from blutgang to caddy
- adds netdata alerts using Caddy prometheus endpoints
- adds netdata to dinar-ephemeral-alpha