### PR TITLE
kaakkuri-ephemeral-alpha: besu to homestakeros module + rm ssd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -303,11 +303,11 @@
     "devour-flake": {
       "flake": false,
       "locked": {
-        "lastModified": 1709858306,
-        "narHash": "sha256-Vey9n9hIlWiSAZ6CCTpkrL6jt4r2JvT2ik9wa2bjeC0=",
+        "lastModified": 1733242247,
+        "narHash": "sha256-RrSH+9vlDDDh+yZao012bvV8Hoej/5poQQYfYlEr6Zw=",
         "owner": "srid",
         "repo": "devour-flake",
-        "rev": "17b711b9deadbbc5629cb7d2b64cf86ae72af3fa",
+        "rev": "017e3a0eb62e2a3d63fb20c5028af71f39a81181",
         "type": "github"
       },
       "original": {
@@ -339,11 +339,6 @@
     },
     "devshell_2": {
       "inputs": {
-        "flake-utils": [
-          "homestakeros",
-          "ethereum-nix",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "homestakeros",
           "ethereum-nix",
@@ -351,11 +346,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717408969,
-        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
         "type": "github"
       },
       "original": {
@@ -380,11 +375,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1730715897,
-        "narHash": "sha256-G/TkPIxcoGkBg0IDJ4athUiKWIyBYWp0ZfwQnilv5Zk=",
+        "lastModified": 1738656545,
+        "narHash": "sha256-rxiRiAJig7GkNoZaxj+7tQYdW9QjBzmpepMnboLgmDs=",
         "owner": "nix-community",
         "repo": "ethereum.nix",
-        "rev": "69bd8dcde94f05bf2e98daeeb33fa1dc9e26b091",
+        "rev": "db665f74737f0d9b269a1ea9677fdb692fd93f87",
         "type": "github"
       },
       "original": {
@@ -562,11 +557,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -650,11 +645,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -677,11 +672,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717405880,
-        "narHash": "sha256-qcXXOnRSl0sGKm7JknntBU4su8/342YKZvjklHsIl+Q=",
+        "lastModified": 1735981876,
+        "narHash": "sha256-PAyEy36HBOOwzChB7D6xKzzkHwiK9ynsRX4/0ZFspgI=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "708c0df1e36b5185a727a3c517a5100e46392792",
+        "rev": "14f071541283aa90e15efc980121a8296f70a2d3",
         "type": "github"
       },
       "original": {
@@ -817,11 +812,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1735052886,
-        "narHash": "sha256-1KUjXJ3lneHZyFZL+GgBZVfZ4kkhUMZ6gohC4LXURnM=",
+        "lastModified": 1740404746,
+        "narHash": "sha256-uDHhV9Ozw9ZueVAaX+YvYly3gxZ8MG8JO4HYc1QmD/Y=",
         "owner": "ponkila",
         "repo": "HomestakerOS",
-        "rev": "a5213786b62b5ac068801d9390ccc8380728b50c",
+        "rev": "d66d59008c4a6faa3ecf1f50b72aad4cea2967a0",
         "type": "github"
       },
       "original": {
@@ -1240,11 +1235,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719317636,
-        "narHash": "sha256-bu0xbu2Z6DDzA9LGV81yJunIti6r7tjUImeR8orAL/I=",
+        "lastModified": 1736241350,
+        "narHash": "sha256-CHd7yhaDigUuJyDeX0SADbTM9FXfiWaeNyY34FL1wQU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c513fc6fb75142f6aec6b7545cb8af2236b80f5",
+        "rev": "8c9fd3e564728e90829ee7dbac6edc972971cd0f",
         "type": "github"
       },
       "original": {
@@ -1255,6 +1250,22 @@
       }
     },
     "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1738574474,
+        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1734875076,
         "narHash": "sha256-Pzyb+YNG5u3zP79zoi8HXYMs15Q5dfjDgwCdUI5B0nY=",
@@ -1270,7 +1281,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_12": {
       "locked": {
         "lastModified": 1731763621,
         "narHash": "sha256-ddcX4lQL0X05AYkrkV2LMFgGdRvgap7Ho8kgon3iWZk=",
@@ -1286,7 +1297,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_12": {
+    "nixpkgs_13": {
       "locked": {
         "lastModified": 0,
         "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
@@ -1412,16 +1423,16 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1717179513,
-        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "lastModified": 1738574474,
+        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1456,18 +1467,15 @@
     },
     "ponkila": {
       "inputs": {
-        "nixpkgs": [
-          "homestakeros",
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_10"
       },
       "locked": {
         "dir": "nixosModules/base",
-        "lastModified": 1729085784,
-        "narHash": "sha256-L9hIPLPBXI6Eo0OMxkkpDunRKHKguP+kd5Dd+XM/mDc=",
+        "lastModified": 1735052886,
+        "narHash": "sha256-1KUjXJ3lneHZyFZL+GgBZVfZ4kkhUMZ6gohC4LXURnM=",
         "owner": "ponkila",
         "repo": "HomestakerOS",
-        "rev": "2983669a1e3e98daf2a1d3359ac9a2247c67be44",
+        "rev": "a5213786b62b5ac068801d9390ccc8380728b50c",
         "type": "github"
       },
       "original": {
@@ -1579,7 +1587,7 @@
         "flake-parts": "flake-parts_3",
         "homestakeros": "homestakeros",
         "homestakeros-base": "homestakeros-base",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_11",
         "sops-nix": "sops-nix",
         "treefmt-nix": "treefmt-nix_4",
         "wirenix": "wirenix"
@@ -1587,7 +1595,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1734546875,
@@ -1678,11 +1686,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719243788,
-        "narHash": "sha256-9T9mSY35EZSM1KAwb7K9zwQ78qTlLjosZgtUGnw4rn4=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "065a23edceff48f948816b795ea8cc6c0dee7cdf",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {
@@ -1734,7 +1742,7 @@
     },
     "wirenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1721448132,

--- a/nixosConfigurations/kaakkuri-ephemeral-alpha/default.nix
+++ b/nixosConfigurations/kaakkuri-ephemeral-alpha/default.nix
@@ -8,15 +8,10 @@
 let
   # General
   infra.ip = "192.168.100.50";
-  sshKeysPath = "/var/mnt/ssd/secrets/ssh/id_ed25519";
+  sshKeysPath = "/var/mnt/nvme/secrets/ssh/id_ed25519";
 in
 {
   boot.initrd.availableKernelModules = [ "xfs" ];
-  fileSystems."/var/mnt/ssd" = lib.mkImageMediaOverride {
-    fsType = "xfs";
-    device = "/dev/mapper/samsung-ssd";
-    neededForBoot = true;
-  };
   fileSystems."/var/mnt/nvme" = lib.mkImageMediaOverride {
     fsType = "xfs";
     device = "/dev/mapper/pro990-data";
@@ -81,7 +76,7 @@ in
     # Wireguard options
     vpn.wireguard = {
       enable = true;
-      configFile = "/var/mnt/ssd/secrets/wg0.conf";
+      configFile = "/var/mnt/nvme/secrets/wg0.conf";
     };
   };
 
@@ -119,11 +114,11 @@ in
   services.bitcoind."mainnet" = {
     enable = true;
     prune = "disable";
-    dataDir = "/var/mnt/ssd/bitcoin/bitcoind";
+    dataDir = "/var/mnt/nvme/bitcoin/bitcoind";
     extraCmdlineOptions = [
       "-server=1"
       "-txindex=0"
-      "-rpccookiefile=/var/mnt/ssd/bitcoin/bitcoind/.cookie"
+      "-rpccookiefile=/var/mnt/nvme/bitcoin/bitcoind/.cookie"
     ];
   };
 
@@ -135,8 +130,8 @@ in
     after = [ "wg-quick-wg0.service" "bitcoind-mainnet.service" ];
 
     script = ''${pkgs.electrs}/bin/electrs \
-      --db-dir /var/mnt/ssd/bitcoin/electrs/db \
-      --cookie-file /var/mnt/ssd/bitcoin/bitcoind/.cookie \
+      --db-dir /var/mnt/nvme/bitcoin/electrs/db \
+      --cookie-file /var/mnt/nvme/bitcoin/bitcoind/.cookie \
       --network bitcoin \
       --electrum-rpc-addr ${infra.ip}:50001 \
       --monitoring-addr 127.0.0.1:4224
@@ -222,7 +217,7 @@ in
       initialClusterToken = "etcd-cluster-1";
       initialClusterState = "new";
       initialCluster = kaakkuri ++ node1 ++ node2;
-      dataDir = "/var/mnt/ssd/etcd";
+      dataDir = "/var/mnt/nvme/etcd";
       openFirewall = true;
     };
 

--- a/nixosConfigurations/kaakkuri-ephemeral-alpha/default.nix
+++ b/nixosConfigurations/kaakkuri-ephemeral-alpha/default.nix
@@ -58,6 +58,20 @@ in
       jwtSecretFile = "/var/mnt/nvme/ethereum/mainnet/jwt.hex";
     };
 
+    # Besu options
+    execution.besu = {
+      enable = true;
+      endpoint = "http://${infra.ip}:8551";
+      dataDir = "/var/mnt/nvme/ethereum/mainnet/besu";
+      jwtSecretFile = "/var/mnt/nvme/ethereum/mainnet/jwt.hex";
+      extraOptions = [
+        "--nat-method=upnp"
+        "--p2p-port=30303"
+        "--sync-mode=CHECKPOINT"
+        "--host-allowlist=\"*\""
+      ];
+    };
+
     # Addons
     addons.mev-boost = {
       enable = true;
@@ -69,38 +83,6 @@ in
       enable = true;
       configFile = "/var/mnt/ssd/secrets/wg0.conf";
     };
-  };
-
-  systemd.services.besu-mainnet = {
-    enable = true;
-
-    description = "mainnet el";
-    requires = [ "wg-quick-wg0.service" ];
-    after = [ "wg-quick-wg0.service" ];
-
-    script = ''${pkgs.besu}/bin/besu \
-      --network=mainnet \
-      --rpc-http-enabled=true \
-      --rpc-http-host=192.168.100.50 \
-      --rpc-http-cors-origins="*" \
-      --rpc-ws-enabled=true \
-      --rpc-ws-host=0.0.0.0 \
-      --host-allowlist="*" \
-      --engine-host-allowlist="*" \
-      --engine-rpc-enabled \
-      --engine-jwt-secret="/var/mnt/nvme/ethereum/mainnet/jwt.hex" \
-      --data-path=/var/mnt/nvme/ethereum/mainnet/besu \
-      --nat-method=upnp \
-      --p2p-port=30303 \
-      --sync-mode=CHECKPOINT \
-      --engine-rpc-port=8551 \
-      --rpc-http-port=8545 \
-      --rpc-ws-port=8546 \
-      --rpc-ws-authentication-enabled=false \
-      --metrics-enabled=true
-    '';
-
-    wantedBy = [ "multi-user.target" ];
   };
 
   systemd.network = {


### PR DESCRIPTION
Moving the Besu configuration inside the homestakeros module using the new `extraOptions` option.

@jhvst, should we expect any issues with these differences?

```bash
nix eval .#nixosConfigurations.kaakkuri-ephemeral-alpha.config.systemd.services.besu-mainnet.script | jq -r '.' | xargs -n1 | grep -v '^$' | sort > old_args.txt`
```

<details> <summary>old_args.txt</summary>

```
--data-path=/var/mnt/nvme/ethereum/mainnet/besu
--engine-host-allowlist=*
--engine-jwt-secret=/var/mnt/nvme/ethereum/mainnet/jwt.hex
--engine-rpc-enabled
--engine-rpc-port=8551
--host-allowlist=*
--metrics-enabled=true
--nat-method=upnp
--network=mainnet
/nix/store/iza9raxq62l9nab6j54bil56jnkr7qzs-besu-24.10.0/bin/besu
--p2p-port=30303
--rpc-http-cors-origins=*
--rpc-http-enabled=true
--rpc-http-host=192.168.100.50
--rpc-http-port=8545
--rpc-ws-authentication-enabled=false
--rpc-ws-enabled=true
--rpc-ws-host=0.0.0.0
--rpc-ws-port=8546
--sync-mode=CHECKPOINT
```

</details>
 
```bash
nix eval .#nixosConfigurations.kaakkuri-ephemeral-alpha.config.systemd.services.besu.serviceConfig.ExecStart | jq -r '.' | xargs -n1 | grep -v '^$' | sort > new_args.txt`
```

<details> <summary>new_args.txt</summary>

```
--data-path=/var/mnt/nvme/ethereum/mainnet/besu
--engine-host-allowlist=*
--engine-jwt-secret=/var/mnt/nvme/ethereum/mainnet/jwt.hex
--engine-rpc-enabled=true
--engine-rpc-port=8551
--host-allowlist=*
--metrics-enabled=true
--nat-method=upnp
--network=mainnet
/nix/store/iza9raxq62l9nab6j54bil56jnkr7qzs-besu-24.10.0/bin/besu
--p2p-port=30303
--rpc-http-api=ETH,NET,WEB3,TRACE,TXPOOL,DEBUG
--rpc-http-authentication-enabled=false
--rpc-http-cors-origins=*
--rpc-http-enabled=true
--rpc-http-host=192.168.100.50
--rpc-http-port=8545
--rpc-ws-api=ETH,NET,WEB3,TRACE,TXPOOL,DEBUG
--rpc-ws-authentication-enabled=false
--rpc-ws-enabled=true
--rpc-ws-host=192.168.100.50
--rpc-ws-port=8546
--sync-mode=CHECKPOINT
```

</details>

```bash
diff old_args.txt new_args.txt
```

```diff
4c4
< --engine-rpc-enabled
---
> --engine-rpc-enabled=true
11a12,13
> --rpc-http-api=ETH,NET,WEB3,TRACE,TXPOOL,DEBUG
> --rpc-http-authentication-enabled=false
15a18
> --rpc-ws-api=ETH,NET,WEB3,TRACE,TXPOOL,DEBUG
18c21
< --rpc-ws-host=0.0.0.0
---
> --rpc-ws-host=192.168.100.50
```

