### PR TITLE
flake: add nixos tests

### DIFF
--- a/nixosConfigurations/ponkila-ephemeral-sigma/default.nix
+++ b/nixosConfigurations/ponkila-ephemeral-sigma/default.nix
@@ -1,8 +1,5 @@
 { pkgs
-, config
 , lib
-, inputs
-, outputs
 , ...
 }:
 {
@@ -108,15 +105,6 @@
 
   services.netdata = {
     enable = true;
-  };
-
-  wirenix = {
-    enable = true;
-    peerName = "ponkila-ephemeral-sigma"; # defaults to hostname otherwise
-    configurer = "networkd"; # defaults to "static", could also be "networkd"
-    keyProviders = [ "agenix-rekey" ]; # could also be ["agenix-rekey"] or ["acl" "agenix-rekey"]
-    secretsDir = ../../nixosModules/wirenix/agenix; # only if you're using agenix-rekey
-    aclConfig = import ../../nixosModules/wirenix/acl.nix;
   };
 
   system.stateVersion = "24.11";


### PR DESCRIPTION
This supersedes the changes made in commit: https://github.com/ponkila/homestaking-infra/commit/f07e771b7ee806ea5a68999da0dcc8c608ed00b6

These tests can be run using `nix flake check -L --impure`.

The diffset for `sigma` include fixes to make the checks pass, including the removal of the recursion in packages.

In the future, we should iterate on this: the imports part can directly reference some other host, by using, e.g., `ponkila-ephemeral-sigma.modules` (the variable comes from the above scope). However, these boots are dependent on local disk, so for now this initial check seems good enough. Tests should probably also put into folder such as `nixosTests`.

Requesting review to have others see this.